### PR TITLE
Typo fix, and rust syntax

### DIFF
--- a/src/utils/prog_utils.rs
+++ b/src/utils/prog_utils.rs
@@ -17,49 +17,45 @@ pub fn execute_command(
     verbosity_level: CommandVerbosityLevel,
 ) -> Result<std::process::Output, std::io::Error> {
     match cmd.output() {
-        Ok(output) => {
-            if output.status.success() {
-                info!(
-                    "command returned successfully ({}) : {:?}",
-                    output.status, cmd
-                );
-                match verbosity_level {
-                    CommandVerbosityLevel::Verbose => {
-                        if !&output.stdout.is_empty() {
-                            info!(
-                                "stdout :\n====\n{}====",
-                                String::from_utf8_lossy(&output.stdout)
-                            );
-                        }
-                        if !&output.stderr.is_empty() {
-                            info!(
-                                "stderr :\n====\n{}====",
-                                String::from_utf8_lossy(&output.stderr)
-                            );
-                        }
-                    }
-                    CommandVerbosityLevel::Quiet => {}
-                }
-                Ok(output)
-            } else {
-                error!("command unsuccesful ({}): {:?}", output.status, cmd);
+        Ok(output) if output.status.success() => {
+            info!(
+                "command returned successfully ({}) : {:?}",
+                output.status, cmd
+            );
+            if let CommandVerbosityLevel::Verbose = verbosity_level {
                 if !&output.stdout.is_empty() {
-                    error!(
+                    info!(
                         "stdout :\n====\n{}====",
                         String::from_utf8_lossy(&output.stdout)
                     );
                 }
                 if !&output.stderr.is_empty() {
-                    error!(
+                    info!(
                         "stderr :\n====\n{}====",
                         String::from_utf8_lossy(&output.stderr)
                     );
                 }
-                Ok(output)
             }
+            Ok(output)
+        }
+        Ok(output) => {
+            error!("command unsuccessful ({}): {:?}", output.status, cmd);
+            if !&output.stdout.is_empty() {
+                error!(
+                    "stdout :\n====\n{}====",
+                    String::from_utf8_lossy(&output.stdout)
+                );
+            }
+            if !&output.stderr.is_empty() {
+                error!(
+                    "stderr :\n====\n{}====",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            Ok(output)
         }
         Err(e) => {
-            error!("command unsuccesful : {:?}", cmd);
+            error!("command unsuccessful : {:?}", cmd);
             error!("error : {}", e);
             Err(e)
         }


### PR DESCRIPTION
## Overview
Two small spelling changes, and two small syntax changes to shorten the execute_command function.

## Spelling
The spelling changes are 'unsuccesful' to 'unsuccessful'


## Rust-isms
In simplified form, we start with:

```rust
match cmd.output() {
    Ok(output) => {
        if output.status.success() {
            // Log success to info
            match verbosity_level {
                CommandVerbosityLevel::Verbose => {
                    // Log stderr and stdout to info
                }
                CommandVerbosityLevel::Quiet => {}
            }
            Ok(output)
        } else {
            // Log failure
            // Log stderr and stdout to error
            Ok(output)
        }
    }
    Err(e) => {
        // Log error
    }
}
```
The first syntax change is to use match guards to inline the if statement:

```rust
match cmd.output() {
    Ok(output) if output.status.success() => {
        // Log success to info
        match verbosity_level {
            CommandVerbosityLevel::Verbose => {
                // Log stderr and stdout to info
            }
            CommandVerbosityLevel::Quiet => {}
        }
    }
    Ok(output) => {
        // Log failure
        // Log stderr and stdout to error
    }
    Err(e) => {
        // Log error
    }
}
```

Lastly, we can use if let to simplify the verbosity check:

```rust
match cmd.output() {
    Ok(output) if output.status.success() => {
        // Log success to info
        if let CommandVerbosityLevel::Verbose = verbosity_level {
            // Log stderr and stdout to info
        }
    }
    Ok(output) => {
        // Log failure
        // Log stderr and stdout to error
    }
    Err(e) => {
        // Log error
    }
}
```