### PR TITLE
feat: adding log for parsing commands

### DIFF
--- a/src/utils/workflow_utils.rs
+++ b/src/utils/workflow_utils.rs
@@ -6,6 +6,7 @@
 use anyhow::{anyhow, bail, Context};
 use chrono::{DateTime, Local};
 use clap::Parser;
+use cmd_lib::log::info;
 use cmd_lib::run_cmd;
 use serde_json::{json, Map, Value};
 use std::fs;
@@ -240,6 +241,7 @@ impl SimpleafWorkflow {
                         })?);
                         // if active, then push to execution queue
                         if active {
+                            info!("Parsing {} command for Step {}", pn, step);
                             // The `Step` will be used for sorting the cmd_queue vector.
                             // All commands must have an valid `Step`.
                             // Note that we store this as a string in json b/c all value in config
@@ -279,8 +281,10 @@ impl SimpleafWorkflow {
                                     field_trajectory_vec: curr_field_trajectory_vec,
                                 });
                             }
-                        }
-                    }
+                        } else {
+                            info!("Skipping {} command for Step {}", pn, step);
+                        } // if active
+                    } // if have ProgramName
                 } else {
                     // If this is not a command record, we move to the next level
                     SimpleafWorkflow::fill_cmd_queue(


### PR DESCRIPTION
As I could not make `clapp::parse_from()` ro return `Result<>`, the think I can do to improve the log is to say beforehand which command is being proceed. This commit adds something like the following:

```
2023-04-09T18:54:14.841654Z  INFO simpleaf::simpleaf_commands::workflow: Processing simpleaf workflow configuration file.
2023-04-09T18:54:14.887752Z  INFO simpleaf::utils::workflow_utils: Skipping simpleaf index command for Step 9
2023-04-09T18:54:14.887769Z  INFO simpleaf::utils::workflow_utils: Skipping simpleaf quant command for Step 10
2023-04-09T18:54:14.887786Z  INFO simpleaf::utils::workflow_utils: Parsing gunzip command for Step 4
2023-04-09T18:54:14.887799Z  INFO simpleaf::utils::workflow_utils: Parsing awk command for Step 8
2023-04-09T18:54:14.887807Z  INFO simpleaf::utils::workflow_utils: Parsing awk command for Step 6


``` 