### PR TITLE
expose piscem workdir parameter `-w` for simpleaf index

### DIFF
--- a/src/simpleaf_commands.rs
+++ b/src/simpleaf_commands.rs
@@ -409,6 +409,16 @@ pub struct IndexOpts {
     )]
     pub hash_seed: u64,
 
+    /// working directory where temporary files should be placed
+    #[arg(
+        long = "work-dir",
+        conflicts_with = "use_piscem",
+        help_heading = "Piscem Index Options",
+        default_value = "./workdir.noindex",
+        display_order = 5
+    )]
+    pub work_dir: PathBuf,
+    
     /// path to output directory (will be created if it doesn't exist)
     #[arg(short, long, display_order = 1)]
     pub output: PathBuf,

--- a/src/simpleaf_commands/indexing.rs
+++ b/src/simpleaf_commands/indexing.rs
@@ -196,7 +196,9 @@ pub fn build_ref_and_index(af_home_path: &Path, opts: IndexOpts) -> anyhow::Resu
             .arg("-s")
             .arg(&ref_seq)
             .arg("--seed")
-            .arg(opts.hash_seed.to_string());
+            .arg(opts.hash_seed.to_string())
+            .arg("-w")
+            .arg(opts.work_dir);
 
         // if the user requested to overwrite, then pass this option
         if opts.overwrite {


### PR DESCRIPTION
In some cloud computing environments, piscem would be extremely slow because of using remote working directory (`./workdir.noindex` by default). This can be avoid by setting the`-w` parameter, which tells piscem to use the specified directory to create intermediate files.