### PR TITLE
add support to cb file with aux info

### DIFF
--- a/resources/custom_chemistries.json
+++ b/resources/custom_chemistries.json
@@ -1,0 +1,8 @@
+{
+    "visiumv1-probe" : "1{b[16]u[12]x:}2{r[50]x:}",
+    "visiumv1" : "1{b[16]u[12]x:}2{r:}",
+    "visiumv4-probe" : "1{b[16]u[12]x:}2{r[50]x:}",
+    "visiumv4" : "1{b[16]u[12]x:}2{r:}",
+    "visiumv5-probe" : "1{b[16]u[12]x:}2{r[50]x:}",
+    "visiumv5" : "1{b[16]u[12]x:}2{r:}"
+}

--- a/resources/custom_chemistries.json
+++ b/resources/custom_chemistries.json
@@ -12,5 +12,6 @@
         "visiumv4" : "fw",
         "visiumv5-probe" : "fw",
         "visiumv5" : "fw"
-    }
+    },
+    "version" : "0.1.0"
 }

--- a/resources/custom_chemistries.json
+++ b/resources/custom_chemistries.json
@@ -4,5 +4,13 @@
     "visiumv4-probe" : "1{b[16]u[12]x:}2{r[50]x:}",
     "visiumv4" : "1{b[16]u[12]x:}2{r:}",
     "visiumv5-probe" : "1{b[16]u[12]x:}2{r[50]x:}",
-    "visiumv5" : "1{b[16]u[12]x:}2{r:}"
+    "visiumv5" : "1{b[16]u[12]x:}2{r:}",
+    "expected_ori" : {
+        "visiumv1-probe" : "fw",
+        "visiumv1" : "fw",
+        "visiumv4-probe" : "fw",
+        "visiumv4" : "fw",
+        "visiumv5-probe" : "fw",
+        "visiumv5" : "fw"
+    }
 }

--- a/resources/permit_list_info.json
+++ b/resources/permit_list_info.json
@@ -63,5 +63,6 @@
     "filename" : "visium-v5_coordinates.txt",
     "cr_filename" : "visium-v5_coordinates.txt",
     "url" : "https://umd.box.com/shared/static/518elp0hmb0es0qbhmp2o34evup4qwwr.txt"
-  }
+  },
+  "version" : "0.1.0"
 }

--- a/resources/permit_list_info.json
+++ b/resources/permit_list_info.json
@@ -33,5 +33,35 @@
     "filename" : "10x_arc_atac_v1.txt",
     "cr_filename" : "737K-arc-v1.txt",
     "url" : "https://umd.box.com/shared/static/4bs2mf4nkvvhviyz90ntdnpfzf6exnlj"
+  },
+  "visiumv1-probe" : {
+    "filename" : "visium-v1_coordinates.txt",
+    "cr_filename" : "visium-v1_coordinates.txt",
+    "url" : "https://umd.box.com/shared/static/851sydyypct2cy4nri98yhelb4a9q3sg.txt"
+  },
+  "visiumv1" : {
+    "filename" : "visium-v1_coordinates.txt",
+    "cr_filename" : "visium-v1_coordinates.txt",
+    "url" : "https://umd.box.com/shared/static/851sydyypct2cy4nri98yhelb4a9q3sg.txt"
+  },
+  "visiumv4-probe" : {
+    "filename" : "visium-v4_coordinates.txt",
+    "cr_filename" : "visium-v4_coordinates.txt",
+    "url" : "https://umd.box.com/shared/static/i4udjwaceixd1em71fol50c3izl1wbzk.txt"
+  },
+  "visiumv4" : {
+    "filename" : "visium-v4_coordinates.txt",
+    "cr_filename" : "visium-v4_coordinates.txt",
+    "url" : "https://umd.box.com/shared/static/i4udjwaceixd1em71fol50c3izl1wbzk.txt"
+  },
+  "visiumv5-probe" : {
+    "filename" : "visium-v5_coordinates.txt",
+    "cr_filename" : "visium-v5_coordinates.txt",
+    "url" : "https://umd.box.com/shared/static/518elp0hmb0es0qbhmp2o34evup4qwwr.txt"
+  },
+  "visiumv5" : {
+    "filename" : "visium-v5_coordinates.txt",
+    "cr_filename" : "visium-v5_coordinates.txt",
+    "url" : "https://umd.box.com/shared/static/518elp0hmb0es0qbhmp2o34evup4qwwr.txt"
   }
 }

--- a/src/atac/commands.rs
+++ b/src/atac/commands.rs
@@ -34,10 +34,11 @@ impl AtacChemistry {
             .filter_map(clap::ValueEnum::to_possible_value)
     }
 
+    #[allow(dead_code)]
     pub fn resource_key(&self) -> String {
         match self {
             Self::TenxV11 => String::from("10x-atac-v1"),
-            Self::TenxV2 => String::from("10x-atac-v1"),
+            Self::TenxV2 => String::from("10x-atac-v2"),
             Self::TenxMulti => String::from("10x-arc-atac-v1"),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,8 +74,8 @@ fn main() -> anyhow::Result<()> {
                 alevin_fry,
             },
         ),
-        Commands::AddChemistry { name, geometry } => {
-            add_chemistry(af_home_path, Commands::AddChemistry { name, geometry })
+        Commands::AddChemistry { name, geometry, expected_ori } => {
+            add_chemistry(af_home_path, Commands::AddChemistry { name, geometry, expected_ori })
         }
         Commands::Inspect {} => inspect_simpleaf(crate_version!(), af_home_path),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,9 +74,18 @@ fn main() -> anyhow::Result<()> {
                 alevin_fry,
             },
         ),
-        Commands::AddChemistry { name, geometry, expected_ori } => {
-            add_chemistry(af_home_path, Commands::AddChemistry { name, geometry, expected_ori })
-        }
+        Commands::AddChemistry {
+            name,
+            geometry,
+            expected_ori,
+        } => add_chemistry(
+            af_home_path,
+            Commands::AddChemistry {
+                name,
+                geometry,
+                expected_ori,
+            },
+        ),
         Commands::Inspect {} => inspect_simpleaf(crate_version!(), af_home_path),
 
         Commands::RefreshProgInfo {} => refresh_prog_info(af_home_path),

--- a/src/simpleaf_commands.rs
+++ b/src/simpleaf_commands.rs
@@ -454,6 +454,9 @@ pub enum Commands {
         /// the geometry to which the chemistry maps
         #[arg(short, long)]
         geometry: String,
+        /// the expected orientation to give to the chemistry
+        #[arg(short, long)]
+        expected_ori: String,
     },
     /// inspect the current configuration
     Inspect {},

--- a/src/simpleaf_commands/chemistry.rs
+++ b/src/simpleaf_commands/chemistry.rs
@@ -17,7 +17,7 @@ pub fn add_chemistry(af_home_path: PathBuf, add_chem_cmd: Commands) -> Result<()
             let _cg = extract_geometry(&geometry)?;
 
             // do we have a custom chemistry file
-            let custom_chem_p = af_home_path.join("custom_chemistries.json");
+            let custom_chem_p = get_custom_chem_path(&af_home_path)?;
 
             let mut custom_chem_file = std::fs::OpenOptions::new()
                 .read(true)

--- a/src/simpleaf_commands/chemistry.rs
+++ b/src/simpleaf_commands/chemistry.rs
@@ -1,9 +1,7 @@
 use crate::utils::af_utils::*;
 
 use anyhow::{bail, Context, Result};
-use serde_json::json;
-use serde_json::Value;
-use std::io::{BufReader, Seek, Write};
+use std::io::{Seek, Write};
 use std::path::PathBuf;
 use tracing::info;
 
@@ -11,50 +9,49 @@ use super::Commands;
 
 pub fn add_chemistry(af_home_path: PathBuf, add_chem_cmd: Commands) -> Result<()> {
     match add_chem_cmd {
-        Commands::AddChemistry { name, geometry } => {
+        Commands::AddChemistry {
+            name,
+            geometry,
+            expected_ori,
+        } => {
             // check geometry string, if no good then
             // propagate error.
             let _cg = extract_geometry(&geometry)?;
 
-            // do we have a custom chemistry file
-            let custom_chem_p = get_custom_chem_path(&af_home_path)?;
-
-            let mut custom_chem_file = std::fs::OpenOptions::new()
-                .read(true)
-                .write(true)
-                .create(true)
-                .truncate(false) // can't truncate because we've not read it yet
-                .open(&custom_chem_p)
-                .with_context({
-                    || {
-                        format!(
-                            "couldn't open the custom chemistry file {}",
-                            custom_chem_p.display()
-                        )
-                    }
-                })?;
-
-            let custom_chem_reader = BufReader::new(&custom_chem_file);
-            let mut v: Value = match serde_json::from_reader(custom_chem_reader) {
-                Ok(sv) => sv,
-                Err(_) => {
-                    // the file was empty so here return an empty json object
-                    json!({})
-                }
-            };
-
-            if let Some(g) = v.get_mut(&name) {
-                let gs = g.as_str().unwrap();
-                info!("chemistry {} already existed, with geometry {}; overwriting geometry specification", name, gs);
-                *g = json!(geometry);
-            } else {
-                info!("inserting chemistry {} with geometry {}", name, geometry);
-                v[name] = json!(geometry);
+            // cannot use expected_ori as the name
+            if &name == "expected_ori" {
+                bail!("The name 'expected_ori' is reserved for the expected orientation of the molecule; Please choose another name");
             }
 
-            custom_chem_file.set_len(0)?;
-            // custom_chem_file.seek(SeekFrom::Start(0))?;
-            // suggested by cargo clippy
+            // init the custom chemistry struct
+            let custom_chem = CustomChemistry {
+                name: name.clone(),
+                geometry: geometry.clone(),
+                expected_ori: ExpectedOri::from_str(&expected_ori)?,
+            };
+
+            // read in the custom chemistry file
+            let custom_chem_p = af_home_path.join("custom_chemistries.json");
+
+            let mut custom_chem_hm = get_custom_chem_hm(&custom_chem_p)?;
+
+            // check if the chemistry already exists and log
+            if let Some(cc) = custom_chem_hm.get(&name) {
+                info!("chemistry {} already existed, with geometry {}; overwriting geometry specification", name, cc.geometry());
+                custom_chem_hm
+                    .entry(name.clone())
+                    .and_modify(|e| *e = custom_chem);
+            } else {
+                info!("inserting chemistry {} with geometry {}", name, geometry);
+                custom_chem_hm.insert(name.clone(), custom_chem);
+            }
+
+            // convert the custom chemistry hashmap to json
+            let v = custom_chem_hm_to_json(&custom_chem_hm)?;
+
+            // write out the new custom chemistry file
+            let mut custom_chem_file = std::fs::File::create(&custom_chem_p)
+                .with_context(|| format!("could not create {}", custom_chem_p.display()))?;
             custom_chem_file.rewind()?;
 
             custom_chem_file

--- a/src/simpleaf_commands/chemistry.rs
+++ b/src/simpleaf_commands/chemistry.rs
@@ -19,8 +19,8 @@ pub fn add_chemistry(af_home_path: PathBuf, add_chem_cmd: Commands) -> Result<()
             let _cg = extract_geometry(&geometry)?;
 
             // cannot use expected_ori as the name
-            if &name == "expected_ori" {
-                bail!("The name 'expected_ori' is reserved for the expected orientation of the molecule; Please choose another name");
+            if (&name == "expected_ori") | (&name == "version") {
+                bail!("The name '{}' is reserved for the expected orientation of the molecule; Please choose another name", &name);
             }
 
             // init the custom chemistry struct

--- a/src/simpleaf_commands/inspect.rs
+++ b/src/simpleaf_commands/inspect.rs
@@ -1,32 +1,23 @@
 use crate::atac::commands::AtacChemistry;
 use crate::utils::{
-    af_utils::{get_custom_chem_path, RnaChemistry},
+    af_utils::{get_custom_chem_hm, RnaChemistry,custom_chem_hm_to_json},
     prog_utils::*,
 };
 use strum::IntoEnumIterator;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde_json::{json, Value};
-use std::io::BufReader;
 use std::path::PathBuf;
 
 pub fn inspect_simpleaf(version: &str, af_home_path: PathBuf) -> Result<()> {
     // Read the JSON contents of the file as an instance of `User`.
     let v: Value = inspect_af_home(af_home_path.as_path())?;
     // do we have a custom chemistry file
-    let custom_chem_p = get_custom_chem_path(&af_home_path)?;
+    let custom_chem_p = af_home_path.join("custom_chemistries.json");
     let chem_info_value = if custom_chem_p.is_file() {
         // parse the custom chemistry json file
-        let custom_chem_file = std::fs::File::open(&custom_chem_p).with_context({
-            || {
-                format!(
-                    "couldn't open the custom chemistry file {}",
-                    custom_chem_p.display()
-                )
-            }
-        })?;
-        let custom_chem_reader = BufReader::new(custom_chem_file);
-        let v: Value = serde_json::from_reader(custom_chem_reader)?;
+        let custom_chem_hm= get_custom_chem_hm(&custom_chem_p)?;
+        let v = custom_chem_hm_to_json(&custom_chem_hm)?;
         json!({
             "custom_chem_path" : custom_chem_p.display().to_string(),
             "custom_geometries" : v

--- a/src/simpleaf_commands/inspect.rs
+++ b/src/simpleaf_commands/inspect.rs
@@ -1,6 +1,6 @@
 use crate::atac::commands::AtacChemistry;
 use crate::utils::{
-    af_utils::{get_custom_chem_hm, RnaChemistry,custom_chem_hm_to_json},
+    af_utils::{custom_chem_hm_to_json, get_custom_chem_hm, RnaChemistry},
     prog_utils::*,
 };
 use strum::IntoEnumIterator;
@@ -16,7 +16,7 @@ pub fn inspect_simpleaf(version: &str, af_home_path: PathBuf) -> Result<()> {
     let custom_chem_p = af_home_path.join("custom_chemistries.json");
     let chem_info_value = if custom_chem_p.is_file() {
         // parse the custom chemistry json file
-        let custom_chem_hm= get_custom_chem_hm(&custom_chem_p)?;
+        let custom_chem_hm = get_custom_chem_hm(&custom_chem_p)?;
         let v = custom_chem_hm_to_json(&custom_chem_hm)?;
         json!({
             "custom_chem_path" : custom_chem_p.display().to_string(),

--- a/src/simpleaf_commands/inspect.rs
+++ b/src/simpleaf_commands/inspect.rs
@@ -1,5 +1,8 @@
 use crate::atac::commands::AtacChemistry;
-use crate::utils::{af_utils::RnaChemistry, prog_utils::*};
+use crate::utils::{
+    af_utils::{get_custom_chem_path, RnaChemistry},
+    prog_utils::*,
+};
 use strum::IntoEnumIterator;
 
 use anyhow::{Context, Result};
@@ -11,7 +14,7 @@ pub fn inspect_simpleaf(version: &str, af_home_path: PathBuf) -> Result<()> {
     // Read the JSON contents of the file as an instance of `User`.
     let v: Value = inspect_af_home(af_home_path.as_path())?;
     // do we have a custom chemistry file
-    let custom_chem_p = af_home_path.join("custom_chemistries.json");
+    let custom_chem_p = get_custom_chem_path(&af_home_path)?;
     let chem_info_value = if custom_chem_p.is_file() {
         // parse the custom chemistry json file
         let custom_chem_file = std::fs::File::open(&custom_chem_p).with_context({

--- a/src/simpleaf_commands/quant.rs
+++ b/src/simpleaf_commands/quant.rs
@@ -445,7 +445,7 @@ pub fn map_and_quant(af_home_path: &Path, opts: MapQuantOpts) -> anyhow::Result<
 
                 let min_cells = opts.min_reads;
                 filter_meth_opt = Some(CellFilterMethod::UnfilteredExternalList(
-                    pl_file.to_string_lossy().into_owned(),
+                    pl_info.final_file.to_string_lossy().into_owned(),
                     min_cells,
                 ));
             } else {
@@ -468,7 +468,7 @@ pub fn map_and_quant(af_home_path: &Path, opts: MapQuantOpts) -> anyhow::Result<
                 PermitListResult::DownloadSuccessful(p) | PermitListResult::AlreadyPresent(p) => {
                     pl_info.init(&p, &opts.output)?;
                     filter_meth_opt = Some(CellFilterMethod::UnfilteredExternalList(
-                        p.to_string_lossy().into_owned(),
+                        pl_info.final_file.to_string_lossy().into_owned(),
                         min_cells,
                     ));
                 }
@@ -482,8 +482,9 @@ pub fn map_and_quant(af_home_path: &Path, opts: MapQuantOpts) -> anyhow::Result<
         }
     } else {
         if let Some(ref filtered_path) = opts.explicit_pl {
+            pl_info.init(filtered_path, &opts.output)?;
             filter_meth_opt = Some(CellFilterMethod::ExplicitList(
-                filtered_path.to_string_lossy().into_owned(),
+                pl_info.final_file.to_string_lossy().into_owned(),
             ));
         };
         if let Some(ref num_forced) = opts.forced_cells {

--- a/src/simpleaf_commands/quant.rs
+++ b/src/simpleaf_commands/quant.rs
@@ -1,4 +1,4 @@
-use crate::utils::af_utils::{self, *};
+use crate::utils::af_utils::*;
 
 use crate::utils::prog_utils;
 use crate::utils::prog_utils::{CommandVerbosityLevel, ReqProgs};
@@ -369,7 +369,7 @@ pub fn map_and_quant(af_home_path: &Path, opts: MapQuantOpts) -> anyhow::Result<
 
     // do we have a custom chemistry file
     let custom_chem_p = af_home_path.join("custom_chemistries.json");
-    let custom_chem_hm = af_utils::get_custom_chem_hm(&custom_chem_p)?;
+    let custom_chem_hm = get_custom_chem_hm(&custom_chem_p)?;
     let custom_chem = custom_chem_hm.get(opts.chemistry.as_str());
 
     let chem = match opts.chemistry.as_str() {
@@ -471,7 +471,7 @@ pub fn map_and_quant(af_home_path: &Path, opts: MapQuantOpts) -> anyhow::Result<
 
             // check the chemistry
             let rc = Chemistry::Rna(chem.clone());
-            let pl_res = af_utils::get_permit_if_absent(af_home_path, &rc)?;
+            let pl_res = get_permit_if_absent(af_home_path, &rc)?;
             let min_cells = opts.min_reads;
             match pl_res {
                 PermitListResult::DownloadSuccessful(p) | PermitListResult::AlreadyPresent(p) => {
@@ -598,7 +598,7 @@ being used by simpleaf"#,
                 // we get the final geometry we want to pass to piscem
                 // check if we can parse the geometry directly, or if we are dealing with a
                 // "complex" geometry.
-                let frag_lib_xform = af_utils::add_or_transform_fragment_library(
+                let frag_lib_xform = add_or_transform_fragment_library(
                     MapperType::Piscem,
                     frag_geometry_str,
                     reads1,
@@ -676,7 +676,7 @@ being used by simpleaf"#,
 
                 // check if we can parse the geometry directly, or if we are dealing with a
                 // "complex" geometry.
-                let frag_lib_xform = af_utils::add_or_transform_fragment_library(
+                let frag_lib_xform = add_or_transform_fragment_library(
                     MapperType::Salmon,
                     frag_geometry_str,
                     reads1,

--- a/src/simpleaf_commands/quant.rs
+++ b/src/simpleaf_commands/quant.rs
@@ -9,12 +9,161 @@ use crate::utils::prog_utils::{CommandVerbosityLevel, ReqProgs};
 use anyhow::{bail, Context};
 use serde_json::json;
 use serde_json::Value;
-use std::io::BufReader;
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use tracing::{error, info, warn};
 
 use super::MapQuantOpts;
+
+struct CBListInfo {
+    pub init_file: PathBuf,
+    pub final_file: PathBuf,
+    pub is_single_column: bool,
+}
+
+impl CBListInfo {
+    fn new() -> Self {
+        CBListInfo {
+            init_file: PathBuf::new(),
+            final_file: PathBuf::new(),
+            is_single_column: true,
+        }
+    }
+    // we iterate the file to see if it only has cb or with affiliated info (by separator \t).
+    fn init(&mut self, pl_file: &PathBuf, output: &PathBuf) -> anyhow::Result<()> {
+        // open pl_file
+        let br = BufReader::new(std::fs::File::open(pl_file).with_context({
+            || format!("Could not open permitlist file {}", pl_file.display())
+        })?);
+
+        // find if there is any "\t"
+        let is_single_column = br
+            .lines()
+            .map(|l| {
+                l.unwrap_or_else(|_| panic!("Could not open permitlist file {}", pl_file.display()))
+            })
+            .any(|l| !l.contains('\t'));
+        // if single column, we are good. Otherwise, we need to write the first column to the final file
+        let final_file: PathBuf;
+        if is_single_column {
+            final_file = pl_file.clone();
+        } else {
+            info!("found multiple columns in the barcode list tsv file, use the first column as the barcodes.");
+
+            // create output dir if doesn't exist
+            if !output.exists() {
+                std::fs::create_dir_all(output)?;
+            }
+            // define final_cb file and open a buffer writer for it
+            final_file = output.join("cb_list.txt");
+            let final_f = std::fs::File::create(&final_file).with_context({
+                || format!("Could not create final cb file {}", final_file.display())
+            })?;
+            let mut final_bw = BufWriter::new(final_f);
+
+            // reinitialize the reader
+            let br = BufReader::new(std::fs::File::open(pl_file)?);
+            for l in br.lines() {
+                // find the tab and write the first column to the final file
+                writeln!(
+                    final_bw,
+                    "{}",
+                    l?.split('\t').next().with_context({
+                        || format!("Could not parse pl file {}", pl_file.display())
+                    })?
+                )?
+            }
+        }
+
+        self.init_file = pl_file.clone();
+        self.final_file = final_file;
+        self.is_single_column = is_single_column;
+        Ok(())
+    }
+    fn update_af_quant_barcodes_tsv(&self, barcode_tsv: &PathBuf) -> anyhow::Result<()> {
+        // if the permit list was single column, then we don't need to do anything
+        // if the permit list was not single column, then we need to add the extra columns into the alevin-fry quants_mat_rows.txt file.
+        if self.is_single_column {
+            return Ok(());
+        }
+
+        // if we are here but the init file doesn't exist, then we have a problem
+        if !self.init_file.exists() {
+            bail!("The CBListInfo struct was not properly initialized. Please report this issue on GitHub.");
+        }
+
+        // if we cannot find the count matrix column files, then complain
+        if !barcode_tsv.exists() {
+            bail!(
+                "The barcode tsv file {} does not exist. Please report it on GitHub",
+                barcode_tsv.display()
+            );
+        }
+
+        info!("Add barcode affiliate info into count matrix row file");
+
+        // The steps are:
+        // 1. read quants_mat_rows.txt as a hashmap
+        // 2. Init a vector to store the final rows, which has the same length as the hashmap
+        // 3. parse the original whitelist file, if we see the cb in the hashmap, then we add the line to the vector at the corresponding position
+        // 4. write the vector to the quants_mat_rows.txt file
+
+        // we read the barcode tsv file as a hashmap where the values are the order of the barcode in the quants_mat_rows.txt file
+        let barcodes_br = BufReader::new(std::fs::File::open(barcode_tsv)?);
+        let mut barcodes: HashMap<String, usize> = HashMap::new();
+        for (lid, l) in barcodes_br.lines().enumerate() {
+            let line: String = l.with_context(|| {
+                format!(
+                    "Could not parse the matrix rows file {}",
+                    barcode_tsv.display()
+                )
+            })?;
+            barcodes.insert(line, lid);
+        }
+
+        // Then, we update the matrix row file.
+        // First, we init a vector to store the rows.
+        let mut row_vec: Vec<String> = vec![String::new(); barcodes.len()];
+
+        // read the whitelist file and parse only those in the matrix row file.
+        let mut allocated_cb = 0;
+        let br = BufReader::new(std::fs::File::open(&self.init_file)?);
+        for l in br.lines() {
+            // identify the cb
+            let line = l?;
+            let cb = line.split('\t').next().with_context({
+                || format!("Could not parse pl file {}", self.init_file.display())
+            })?;
+
+            // if the cb is in the quantified barcodes, then we add the line to the row_vec
+            if let Some(rowid) = barcodes.get(cb) {
+                row_vec[*rowid] = line;
+                allocated_cb += 1;
+            }
+        }
+
+        // if the number of allocated cb is less than the total number of cb in the quantified matrix, we complain
+        if allocated_cb != barcodes.len() {
+            bail!(
+                "Only {} out of {} quantified barcodes are found in the whitelist. Please report this issue on GitHub.",
+                allocated_cb,
+                barcodes.len()
+            );
+        }
+
+        // create a buffer writer to overwrite the quants_mat_rows.txt file
+        let mut final_barcodes_bw = BufWriter::new(std::fs::File::create(barcode_tsv)?);
+
+        // write the row_vec to the final barcodes.tsv file
+        for l in row_vec {
+            writeln!(final_barcodes_bw, "{}", l)?;
+        }
+
+        Ok(())
+    }
+}
 
 enum IndexType {
     Salmon(PathBuf),
@@ -222,8 +371,7 @@ pub fn map_and_quant(af_home_path: &Path, opts: MapQuantOpts) -> anyhow::Result<
     }
 
     // do we have a custom chemistry file
-    let custom_chem_p = af_home_path.join("custom_chemistries.json");
-    let custom_chem_exists = custom_chem_p.is_file();
+    let custom_chem_p = af_utils::get_custom_chem_path(af_home_path)?;
 
     let chem = match opts.chemistry.as_str() {
         "10xv2" => RnaChemistry::TenxV2,
@@ -232,30 +380,18 @@ pub fn map_and_quant(af_home_path: &Path, opts: MapQuantOpts) -> anyhow::Result<
         "10xv3-5p" => RnaChemistry::TenxV35P,
         "10xv4-3p" => RnaChemistry::TenxV43P,
         s => {
-            if custom_chem_exists {
-                // parse the custom chemistry json file
-                let custom_chem_file = std::fs::File::open(&custom_chem_p).with_context({
-                    || {
-                        format!(
-                            "couldn't open the custom chemistry file {}",
-                            custom_chem_p.display()
-                        )
-                    }
-                })?;
-                let custom_chem_reader = BufReader::new(custom_chem_file);
-                let v: Value = serde_json::from_reader(custom_chem_reader)?;
-                let rchem = match v[s.to_string()].as_str() {
-                    Some(chem_str) => {
-                        info!("custom chemistry {} maps to geometry {}", s, &chem_str);
-                        RnaChemistry::Other(chem_str.to_string())
-                    }
-                    None => RnaChemistry::Other(s.to_string()),
-                };
-                rchem
-            } else {
-                // pass along whatever the user gave us
-                RnaChemistry::Other(s.to_string())
-            }
+            // parse the custom chemistry json file
+            let custom_chem_file = std::fs::File::open(&custom_chem_p)?;
+            let custom_chem_reader = BufReader::new(custom_chem_file);
+            let v: Value = serde_json::from_reader(custom_chem_reader)?;
+            let rchem = match v[s.to_string()].as_str() {
+                Some(chem_str) => {
+                    info!("custom chemistry {} maps to geometry {}", s, &chem_str);
+                    RnaChemistry::Other(chem_str.to_string())
+                }
+                None => RnaChemistry::Other(s.to_string()),
+            };
+            rchem
         }
     };
 
@@ -290,6 +426,7 @@ pub fn map_and_quant(af_home_path: &Path, opts: MapQuantOpts) -> anyhow::Result<
     }
 
     let mut filter_meth_opt = None;
+    let mut pl_info = CBListInfo::new();
 
     // based on the filtering method
     if let Some(ref pl_file) = opts.unfiltered_pl {
@@ -302,6 +439,10 @@ pub fn map_and_quant(af_home_path: &Path, opts: MapQuantOpts) -> anyhow::Result<
             // the user has explicily passed a file along, so try
             // to use that
             if pl_file.is_file() {
+                // we read the file to see if there is additional columns separated by \t.
+                // unwrap is safe here cuz we defined it above
+                pl_info.init(pl_file, &opts.output)?;
+
                 let min_cells = opts.min_reads;
                 filter_meth_opt = Some(CellFilterMethod::UnfilteredExternalList(
                     pl_file.to_string_lossy().into_owned(),
@@ -325,6 +466,7 @@ pub fn map_and_quant(af_home_path: &Path, opts: MapQuantOpts) -> anyhow::Result<
             let min_cells = opts.min_reads;
             match pl_res {
                 PermitListResult::DownloadSuccessful(p) | PermitListResult::AlreadyPresent(p) => {
+                    pl_info.init(&p, &opts.output)?;
                     filter_meth_opt = Some(CellFilterMethod::UnfilteredExternalList(
                         p.to_string_lossy().into_owned(),
                         min_cells,
@@ -741,6 +883,11 @@ being used by simpleaf"#,
             }
         }
     }
+
+    // If a permit/explit list with auxilary info was provided,
+    // we add the auxilary info to the barcodes.tsv file.
+    let quants_mat_rows_p = gpl_output.join("alevin").join("quants_mat_rows.txt");
+    pl_info.update_af_quant_barcodes_tsv(&quants_mat_rows_p)?;
 
     // write the relevant info about
     // our run to file.

--- a/src/simpleaf_commands/quant.rs
+++ b/src/simpleaf_commands/quant.rs
@@ -379,18 +379,24 @@ pub fn map_and_quant(af_home_path: &Path, opts: MapQuantOpts) -> anyhow::Result<
         "10xv3-5p" => RnaChemistry::TenxV35P,
         "10xv4-3p" => RnaChemistry::TenxV43P,
         s => {
-            let rchem = if let Some(chem) = custom_chem {
+            if let Some(chem) = custom_chem {
                 info!(
                     "custom chemistry {} maps to geometry {}",
                     s,
                     chem.geometry()
                 );
-                RnaChemistry::Other(chem.geometry().to_string())
+                RnaChemistry::Other(s.to_string())
             } else {
                 RnaChemistry::Other(s.to_string())
-            };
-            rchem
+            }
         }
+    };
+
+    // we get the final string we want to use for the fragment geometry later
+    let frag_geometry_str = if let Some(cc) = custom_chem {
+        cc.geometry()
+    } else {
+        chem.as_str()
     };
 
     let ori: String;
@@ -589,11 +595,12 @@ being used by simpleaf"#,
                     );
                 }
 
+                // we get the final geometry we want to pass to piscem
                 // check if we can parse the geometry directly, or if we are dealing with a
                 // "complex" geometry.
                 let frag_lib_xform = af_utils::add_or_transform_fragment_library(
                     MapperType::Piscem,
-                    chem.as_str(),
+                    frag_geometry_str,
                     reads1,
                     reads2,
                     &mut piscem_quant_cmd,
@@ -671,7 +678,7 @@ being used by simpleaf"#,
                 // "complex" geometry.
                 let frag_lib_xform = af_utils::add_or_transform_fragment_library(
                     MapperType::Salmon,
-                    chem.as_str(),
+                    frag_geometry_str,
                     reads1,
                     reads2,
                     &mut salmon_quant_cmd,

--- a/src/simpleaf_commands/workflow.rs
+++ b/src/simpleaf_commands/workflow.rs
@@ -189,9 +189,7 @@ pub fn list_workflows<T: AsRef<Path>>(af_home_path: T) -> anyhow::Result<()> {
 /// This program takes a string representing the name of a published workflow, and copy the
 /// folder of that workflow in the protocol estuary to the provided output directory
 /// as a sub-directory.
-
 // TODO: implement essential only
-
 pub fn get_wokflow<T: AsRef<Path>>(
     af_home_path: T,
     gw_cmd: WorkflowCommands,
@@ -367,7 +365,6 @@ pub fn get_wokflow<T: AsRef<Path>>(
 ///      higher than 0.11.0
 /// 3. index: (Optional): this field records all simpleaf index commands that need to be run.
 /// 4. quant: (Optional): this field records all simpleaf quant commands that need to be run.
-
 // TODO: add a `skip` argument for skipping steps
 pub fn run_workflow<T: AsRef<Path>>(
     af_home_path: T,

--- a/src/utils/af_utils.rs
+++ b/src/utils/af_utils.rs
@@ -1,15 +1,17 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use cmd_lib::run_fun;
 use phf::phf_map;
 use seq_geom_parser::{AppendToCmdArgs, FragmentGeomDesc, PiscemGeomDesc, SalmonSeparateGeomDesc};
 use seq_geom_xform::{FifoXFormData, FragmentGeomDescExt};
-use serde_json::Value;
-use std::fmt;
-use std::path::{Path, PathBuf};
+use serde_json;
+use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::io::BufReader;
+use std::path::{Path, PathBuf};
+use std::fmt;
 
 use strum_macros::EnumIter;
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::atac::commands::AtacChemistry;
 use crate::utils::prog_utils;
@@ -231,151 +233,88 @@ pub fn add_chemistry_to_args_piscem(chem_str: &str, cmd: &mut std::process::Comm
     Ok(())
 }
 
+static PERMIT_DIRECT_URL: &str = "https://raw.githubusercontent.com/COMBINE-lab/simpleaf/dev/resources/permit_list_info.json"
+
 pub fn get_permit_if_absent(af_home: &Path, chem: &Chemistry) -> Result<PermitListResult> {
+    //check if the permit_list_info.json file exists
+    // if we have permit list file in af_home, there should be a permit_list_info.json file
+    // if it's not there, we should download it
+    let permit_info_p = af_home.join("permit_list_info.json");
+    if !permit_info_p.exists() {
+        // download the permit_list_info.json file if needed
+        prog_utils::download_to_file(PERMIT_DIRECT_URL, &permit_info_p)?;
+    }
+    // read the permit_list_info.json file
+    let permit_info_file = std::fs::File::open(&permit_info_p)?;
+    let permit_info_reader = BufReader::new(permit_info_file);
+    let v: Value = serde_json::from_reader(permit_info_reader)?;
+
+    // get chemistry name
+    let chem_name = match chem {
+        Chemistry::Rna(rna_chem) => {
+            rna_chem.as_str()
+        }
+        Chemistry::Atac(atac_chem) => {
+            atac_chem.as_str()
+        }
+    };
+
     // check if the file already exists
     let odir = af_home.join("plist");
-    match chem {
-        Chemistry::Rna(rna_chem) => match rna_chem {
-            RnaChemistry::TenxV2 => {
-                let chem_file = "10x_v2_permit.txt";
-                if odir.join(chem_file).exists() {
-                    return Ok(PermitListResult::AlreadyPresent(odir.join(chem_file)));
-                }
-            }
-            RnaChemistry::TenxV25P => {
-                // v2 and v2-5' use the same permit list
-                let chem_file = "10x_v2_permit.txt";
-                if odir.join(chem_file).exists() {
-                    return Ok(PermitListResult::AlreadyPresent(odir.join(chem_file)));
-                }
-            }
-            RnaChemistry::TenxV3 => {
-                let chem_file = "10x_v3_permit.txt";
-                if odir.join(chem_file).exists() {
-                    return Ok(PermitListResult::AlreadyPresent(odir.join(chem_file)));
-                }
-            }
-            RnaChemistry::TenxV35P => {
-                let chem_file = "10x_v3_5p_permit.txt";
-                if odir.join(chem_file).exists() {
-                    return Ok(PermitListResult::AlreadyPresent(odir.join(chem_file)));
-                }
-            }
-            RnaChemistry::TenxV43P => {
-                let chem_file = "10x_v4_3p_permit.txt";
-                if odir.join(chem_file).exists() {
-                    return Ok(PermitListResult::AlreadyPresent(odir.join(chem_file)));
-                }
-            }
-            _ => {
-                return Ok(PermitListResult::UnregisteredChemistry);
-            }
-        },
-        Chemistry::Atac(atac_chem) => match atac_chem {
-            AtacChemistry::TenxV11 | AtacChemistry::TenxV2 => {
-                let chem_file = "10x_atac_v1_v11_v2.txt";
-                if odir.join(chem_file).exists() {
-                    return Ok(PermitListResult::AlreadyPresent(odir.join(chem_file)));
-                }
-            }
-            AtacChemistry::TenxMulti => {
-                let chem_file = "10x_arc_atac_v1.txt";
-                if odir.join(chem_file).exists() {
-                    return Ok(PermitListResult::AlreadyPresent(odir.join(chem_file)));
-                }
-            }
-        },
-    }
 
-    // the file doesn't exist, so get the json file that gives us
-    // the chemistry name to permit list URL mapping.
-    let permit_dict_url = "https://raw.githubusercontent.com/COMBINE-lab/simpleaf/dev/resources/permit_list_info.json";
-    let request_result = minreq::get(permit_dict_url).send().inspect_err( |err| {
-        error!("Could not obtain the permit list metadata from {}; encountered {:?}.", &permit_dict_url, &err);
-        error!("This may be a transient failure, or could be because the client is lacking a network connection. \
-        In the latter case, please consider manually providing the appropriate permit list file directly \
-        via the command line to avoid an attempt by simpleaf to automatically obtain it.");
-    })?;
-    let permit_dict: serde_json::Value = request_result.json::<serde_json::Value>()?;
-    let opt_chem_file: Option<String>;
-    let opt_dl_url: Option<String>;
-    // parse the JSON appropriately based on the chemistry we have
-    match chem {
-        Chemistry::Rna(rna_chem) => match rna_chem {
-            RnaChemistry::TenxV2
-            | RnaChemistry::TenxV25P
-            | RnaChemistry::TenxV3
-            | RnaChemistry::TenxV35P
-            | RnaChemistry::TenxV43P => {
-                let chem_key = chem.as_str();
-                if let Some(d) = permit_dict.get(chem_key) {
-                    opt_chem_file = d
-                        .get("filename")
-                        .expect("value for filename field should be a string")
-                        .as_str()
-                        .map(|cf| cf.to_string());
-                    opt_dl_url = d
-                        .get("url")
-                        .expect("value for url field should be a string")
-                        .as_str()
-                        .map(|url| url.to_string());
-                } else {
-                    bail!(
-                        "could not obtain \"{}\" key from the fetched permit_dict at {} = {:?}",
-                        chem_key,
-                        permit_dict_url,
-                        permit_dict
-                    )
-                }
-            }
-            _ => {
-                return Ok(PermitListResult::UnregisteredChemistry);
-            }
-        },
-        Chemistry::Atac(atac_chem) => match atac_chem {
-            AtacChemistry::TenxV11 | AtacChemistry::TenxV2 | AtacChemistry::TenxMulti => {
-                let chem_key = atac_chem.resource_key();
-                if let Some(d) = permit_dict.get(&chem_key) {
-                    opt_chem_file = d
-                        .get("filename")
-                        .expect("value for filename field should be a string")
-                        .as_str()
-                        .map(|cf| cf.to_string());
-                    opt_dl_url = d
-                        .get("url")
-                        .expect("value for url field should be a string")
-                        .as_str()
-                        .map(|url| url.to_string());
-                } else {
-                    bail!(
-                        "could not obtain \"{}\" key from the fetched permit_dict at {} = {:?}",
-                        chem_key,
-                        permit_dict_url,
-                        permit_dict
-                    )
-                }
-            }
-        },
-    }
+    // get the permit list file name and url if its in the permit info file
+    if let Some(chem_info) = v.get(chem_name) {
+        // get chemistry file name
+        let chem_filename = chem_info
+            .get("filename")
+            .with_context(|| {
+                format!(
+                    "could not obtain the filename field for chemistry {} from the permit_list_info.json file. Please report this issue onto the simpleaf github repository. The value obtained was {:?}",
+                    chem_name,
+                    chem_info
+                )
+            })?
+            .as_str()
+            .with_context(|| {
+                format!(
+                    "value for filename field should be a string for chemistry {} from the permit_list_info.json file. Please report this issue onto the simpleaf github repository. The value obtained was {:?}",
+                    chem_name,
+                    chem_info
+                )
+            })?
+            .to_string();
 
-    // actually download the permit list if we need it and don't have it.
-    if let (Some(chem_file), Some(dl_url)) = (opt_chem_file, opt_dl_url) {
-        if odir.join(&chem_file).exists() {
-            Ok(PermitListResult::AlreadyPresent(odir.join(&chem_file)))
-        } else {
-            run_fun!(mkdir -p $odir)?;
-
-            let output_file = odir.join(&chem_file);
-            prog_utils::download_to_file(dl_url, &output_file)?;
-
-            Ok(PermitListResult::DownloadSuccessful(odir.join(&chem_file)))
+        //if it exists, return the path
+        if odir.join(&chem_filename).is_file() {
+            return Ok(PermitListResult::AlreadyPresent(odir.join(&chem_filename)));
         }
+
+        // now, we download it
+        let dl_url = chem_info
+            .get("url")
+            .with_context(|| {
+                format!(
+                    "could not obtain the url field for chemistry {} from the permit_list_info.json file. Please report this issue onto the simpleaf github repository. The value obtained was {:?}",
+                    chem_name,
+                    chem_info
+                )
+            })?
+            .as_str()
+            .with_context(|| {
+                format!(
+                    "value for url field should be a string for chemistry {} from the permit_list_info.json file. Please report this issue onto the simpleaf github repository. The value obtained was {:?}",
+                    chem_name,
+                    chem_info
+                )
+            })?
+            .to_string();
+        
+        // download the file
+        let output_file = odir.join(&chem_filename);
+        prog_utils::download_to_file(dl_url, &output_file)?;
+        return Ok(PermitListResult::DownloadSuccessful(output_file));
     } else {
-        bail!(
-            "could not properly parse the permit dictionary obtained from {} = {:?}",
-            permit_dict_url,
-            permit_dict
-        );
+        return Ok(PermitListResult::UnregisteredChemistry)
     }
 }
 
@@ -518,16 +457,65 @@ pub fn add_or_transform_fragment_library(
 static CUSTOM_CHEM_URL: &str = "https://raw.githubusercontent.com/an-altosian/simpleaf/spatial/resources/custom_chemistries.json";
 // "https://raw.githubusercontent.com/COMBINE-lab/simpleaf/dev/resources/custom_chem.json";
 
+#[derive(Debug, Clone)]
+pub enum ExpectedOri {
+    Forward,
+    Reverse,
+    Both,
+}
+
+impl ExpectedOri {
+    pub fn as_str(&self) -> &str {
+        match self {
+            ExpectedOri::Forward => "fw",
+            ExpectedOri::Reverse => "rc",
+            ExpectedOri::Both => "both",
+        }
+    }
+
+    // construct the expected_ori from a str
+    pub fn from_str(s: &str) -> Result<ExpectedOri> {
+        match s {
+            "fw" => Ok(ExpectedOri::Forward),
+            "rc" => Ok(ExpectedOri::Reverse),
+            "both" => Ok(ExpectedOri::Both),
+            _ => Err(anyhow!("Invalid expected_ori value: {}", s)),
+        }
+    }
+}
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct CustomChemistry {
+    pub name: String,
+    pub geometry: String,
+    pub expected_ori: ExpectedOri,
+}
+
+#[allow(dead_code)]
+impl CustomChemistry {
+    pub fn geometry(&self) -> &str {
+        self.geometry.as_str()
+    }
+
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    pub fn expected_ori(&self) -> ExpectedOri {
+        self.expected_ori.clone()
+    }
+}
+
 /// This function gets the custom chemistry from the `af_home_path` directory.
 /// If the file doesn't exist, it downloads the file from the `url` and saves it
-pub fn get_custom_chem_path(af_home_path: &Path) -> Result<PathBuf> {
+pub fn get_custom_chem_hm(custom_chem_p: &Path) -> Result<HashMap<String, CustomChemistry>> {
     // check if the custom_chemistries.json file exists
-    let custom_chem_p = af_home_path.join("custom_chemistries.json");
     let custom_chem_exists = custom_chem_p.is_file();
 
+    // get the file
     if custom_chem_exists {
         // test if the file is good
-        let custom_chem_file = std::fs::File::open(&custom_chem_p).with_context(|| {
+        let custom_chem_file = std::fs::File::open(custom_chem_p).with_context(|| {
             format!(
                 "Couldn't open the existing custom chemistry file. Please consider delete it from {}",
                 custom_chem_p.display()
@@ -543,7 +531,124 @@ pub fn get_custom_chem_path(af_home_path: &Path) -> Result<PathBuf> {
     } else {
         // download the custom_chemistries.json file if needed
         let custom_chem_url = CUSTOM_CHEM_URL;
-        prog_utils::download_to_file(custom_chem_url, &custom_chem_p)?;
+        prog_utils::download_to_file(custom_chem_url, custom_chem_p)?;
     }
-    Ok(custom_chem_p)
+
+    // load the file
+    let custom_chem_file = std::fs::File::open(custom_chem_p)?;
+    let custom_chem_reader = BufReader::new(custom_chem_file);
+    let v: Value = serde_json::from_reader(custom_chem_reader)?;
+    get_custom_chem_hm_from_value(v, custom_chem_p)
+}
+
+pub fn get_custom_chem_hm_from_value(
+    v: Value,
+    custom_chem_p: &Path,
+) -> Result<HashMap<String, CustomChemistry>> {
+    let v_obj = v.as_object().with_context(|| {
+        format!(
+            "Couldn't parse the existing custom chemistry file. Please consider delete it from {}",
+            custom_chem_p.display()
+        )
+    })?;
+
+    let expected_ori_key = String::from("expected_ori");
+    // check if expected_ori exists
+    let expected_oris = v_obj.get(&expected_ori_key);
+
+    // warn if the expected_ori doesn't exist
+    if expected_oris.is_none() {
+        warn!("The expected_ori key is not found in the custom chemistry file, indicating it is an outdated version. All custom chemistries'  expected_ori will be treated as `both`. Please consider deleting the existing file from {}", custom_chem_p.display());
+    }
+
+    // Then we go over the keys and values and create a hashmap
+    let mut custom_chem_map = HashMap::new();
+
+    // Except the expected_ori key, others are custom chemistries
+    for (key, value) in v_obj.iter() {
+        // skip the expected_ori key
+        if key == &expected_ori_key {
+            continue;
+        }
+
+        // Now, we would expect we are working on a custom chemistry
+        let chem_spec = value.as_str().with_context(|| {
+            format!(
+                "Couldn't parse chemistry {} : {} in the custom chemistry file. Please consider delete the file from {}",
+                key,
+                value,
+                custom_chem_p.display()
+            )
+        })?;
+        let _cg = extract_geometry(chem_spec).with_context(|| {
+            format!(
+                "Couldn't parse the geometry for {}: {}. Please consider delete the file from {}",
+                key,
+                chem_spec,
+                custom_chem_p.display()
+            )
+        })?;
+
+        // insert it into the custom_chem_map
+        custom_chem_map.insert(key.clone(), CustomChemistry {
+            name: key.clone(),
+            geometry: chem_spec.to_string(),
+            expected_ori: {
+                // if expected_ori exists, we use it
+                if let Some(expected_ori_value) = expected_oris {
+                    let default_v = json!("both");
+                    // get the expected_ori str
+                    let expected_ori = expected_ori_value.get(key).unwrap_or(&default_v).as_str().with_context(|| {
+                        format!(
+                            "Couldn't parse the expected_ori for {}: {}. Please consider delete the file from {}",
+                            key,
+                            expected_ori_value.get(key).unwrap_or(&json!("both")),
+                            custom_chem_p.display()
+                        )
+                    })?;
+                    // convert it to expected_ori enum
+                    ExpectedOri::from_str(expected_ori).with_context(|| {
+                        format!(
+                            "Couldn't parse the expected_ori for {}: {}. Please consider delete the file from {}",
+                            key,
+                            expected_ori,
+                            custom_chem_p.display()
+                        )
+                    })?
+                } else {
+                    ExpectedOri::Both
+                }
+            }
+        });
+    }
+
+    Ok(custom_chem_map)
+}
+
+pub fn custom_chem_hm_to_json(custom_chem_hm: &HashMap<String, CustomChemistry>) -> Result<Value> {
+
+    // first create the name to genometry mapping
+    let mut v: Value = custom_chem_hm
+        .iter()
+        .map(|(k, v)| {
+            json!({
+                k.clone() : v.geometry().to_string()
+            })
+        })
+        .collect();
+
+    // add in expected ori mapping
+    let expected_ori_v: Value = custom_chem_hm
+        .iter()
+        .map(|(k, v)| {
+            json!({
+                k.clone() : v.expected_ori().as_str().to_string()
+            })
+        })
+        .collect();
+
+    // add the expected_ori to the geometry json
+    v["expected_ori"] = expected_ori_v;
+    
+    Ok(v)
 }

--- a/src/utils/af_utils.rs
+++ b/src/utils/af_utils.rs
@@ -20,11 +20,11 @@ use crate::utils::prog_utils;
 
 // TODO: Update the path while merging
 static PERMIT_LIST_INFO_VERSION: &str = "0.1.0";
-static PERMIT_LIST_INFO_URL: &str = "https://raw.githubusercontent.com/an-altosian/simpleaf/spatial/resources/permit_list_info.json";
+static PERMIT_LIST_INFO_URL: &str = "https://raw.githubusercontent.com/COMBINE-lab/simpleaf/spatial/resources/permit_list_info.json";
 // "https://raw.githubusercontent.com/COMBINE-lab/simpleaf/dev/resources/permit_list_info.json";
 
 static CUSTOM_CHEMISTRIES_VERSION: &str = "0.1.0";
-static CUSTOM_CHEMISTRIES_URL: &str = "https://raw.githubusercontent.com/an-altosian/simpleaf/spatial/resources/custom_chemistries.json";
+static CUSTOM_CHEMISTRIES_URL: &str = "https://raw.githubusercontent.com/COMBINE-lab/simpleaf/spatial/resources/custom_chemistries.json";
 // "https://raw.githubusercontent.com/COMBINE-lab/simpleaf/dev/resources/custom_chem.json";
 
 /// The map from pre-specified chemistry types that salmon knows

--- a/src/utils/af_utils.rs
+++ b/src/utils/af_utils.rs
@@ -5,8 +5,8 @@ use seq_geom_parser::{AppendToCmdArgs, FragmentGeomDesc, PiscemGeomDesc, SalmonS
 use seq_geom_xform::{FifoXFormData, FragmentGeomDescExt};
 use serde_json::Value;
 use std::fmt;
-use std::io::BufReader;
 use std::path::{Path, PathBuf};
+use std::io::BufReader;
 
 use strum_macros::EnumIter;
 use tracing::error;
@@ -515,8 +515,8 @@ pub fn add_or_transform_fragment_library(
     }
 }
 
-static CUSTOM_CHEM_URL: &str =
-    "https://raw.githubusercontent.com/COMBINE-lab/simpleaf/dev/resources/custom_chem.json";
+static CUSTOM_CHEM_URL: &str = "https://raw.githubusercontent.com/an-altosian/simpleaf/spatial/resources/custom_chemistries.json";
+// "https://raw.githubusercontent.com/COMBINE-lab/simpleaf/dev/resources/custom_chem.json";
 
 /// This function gets the custom chemistry from the `af_home_path` directory.
 /// If the file doesn't exist, it downloads the file from the `url` and saves it

--- a/src/utils/af_utils.rs
+++ b/src/utils/af_utils.rs
@@ -256,7 +256,7 @@ pub fn get_permit_if_absent(af_home: &Path, chem: &Chemistry) -> Result<PermitLi
     let permit_info_reader = BufReader::new(permit_info_file);
     let v: Value = serde_json::from_reader(permit_info_reader)?;
 
-    let fake_version = json!("0.0.1");
+    let fake_version = json!("0.0.0");
     // get the version. If it is an old version, suggest the user to delete it
     let version = v
         .get("version")
@@ -275,7 +275,7 @@ pub fn get_permit_if_absent(af_home: &Path, chem: &Chemistry) -> Result<PermitLi
         version,
     ) {
         Ok(af_ver) => info!("found permit_list_info.json version {:#}; Proceeding", af_ver),
-        Err(_) => warn!("found outdated permit list info file (with version {}) at {:#?}. Please consider delete it.", version, &permit_info_p)
+        Err(_) => warn!("found outdated permit list info file with version {}. Please consider delete it from {:#?}.", version, &permit_info_p)
     }
 
     // get chemistry name
@@ -553,7 +553,7 @@ pub fn get_custom_chem_hm(custom_chem_p: &Path) -> Result<HashMap<String, Custom
         })?;
 
         // we check if the file is up to date
-        let fake_version = json!("0.0.1");
+        let fake_version = json!("0.0.0");
         // get the version. If it is an old version, suggest the user to delete it
         let version = v
             .get("version")
@@ -573,7 +573,7 @@ pub fn get_custom_chem_hm(custom_chem_p: &Path) -> Result<HashMap<String, Custom
             version,
         ) {
             Ok(af_ver) => info!("found permit_list_info.json version {:#}; Proceeding", af_ver),
-            Err(_) => warn!("found outdated permit list info file (with version {}) at {:#?}. Please consider delete it.", version, custom_chem_p)
+            Err(_) => warn!("found outdated permit list info file with version {}. Please consider delete it from {:#?}.", version, custom_chem_p)
         }
     } else {
         // download the custom_chemistries.json file if needed
@@ -614,7 +614,7 @@ pub fn get_custom_chem_hm_from_value(
     // Except the expected_ori key, others are custom chemistries
     for (key, value) in v_obj.iter() {
         // skip the expected_ori key
-        if key == &expected_ori_key {
+        if (key == expected_ori_key.as_str()) | (key == "version") {
             continue;
         }
 

--- a/src/utils/prog_utils.rs
+++ b/src/utils/prog_utils.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 use cmd_lib::run_fun;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
@@ -61,11 +61,12 @@ pub fn download_to_file<T: AsRef<str>>(url: T, file_path: &Path) -> Result<()> {
             );
         }
         x => {
-            bail!(
-                "could not obtain the permit list; HTTP status code {}, reason {}",
+            return Err(anyhow!(
+                "could not obtain the requested file from {}; HTTP status code {}, reason {}",
+                url,
                 x,
                 request.reason_phrase
-            );
+            ))
         }
     }
 

--- a/src/utils/prog_utils.rs
+++ b/src/utils/prog_utils.rs
@@ -4,6 +4,7 @@ use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::ffi::{OsStr, OsString};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::LazyLock;
@@ -41,12 +42,13 @@ pub fn shell<S: AsRef<OsStr>>(cmd: S) -> Command {
     command
 }
 
-pub fn download_to_file<T: AsRef<str>>(url: T, filename: &str) -> Result<()> {
+pub fn download_to_file<T: AsRef<str>>(url: T, file_path: &Path) -> Result<()> {
     let url = url.as_ref();
 
     debug!(
         "Downloading file from {} and writing to file {}",
-        url, filename
+        url,
+        file_path.display()
     );
 
     let request = minreq::get(url).with_timeout(120).send()?;
@@ -67,8 +69,7 @@ pub fn download_to_file<T: AsRef<str>>(url: T, filename: &str) -> Result<()> {
         }
     }
 
-    let mut out_file = std::fs::File::create(filename)?;
-    use std::io::Write;
+    let mut out_file = std::fs::File::create(file_path)?;
     out_file.write_all(request.as_bytes())?;
     Ok(())
 }

--- a/src/utils/workflow_utils.rs
+++ b/src/utils/workflow_utils.rs
@@ -969,7 +969,6 @@ impl WorkflowLog {
     /// 1. the `active` field of the executed commands in execution log
     /// 2. cmd runtime
     /// 3. number of succeed commands.
-
     pub fn update(&mut self, field_trajectory_vec: &[usize]) -> anyhow::Result<()> {
         // update cmd run time
         if let Some(command_runtime) = &self.command_runtime {

--- a/src/utils/workflow_utils.rs
+++ b/src/utils/workflow_utils.rs
@@ -1293,8 +1293,7 @@ pub fn get_protocol_estuary<T: AsRef<Path>>(
             run_cmd!(mkdir -p $pe_dir)?;
         }
 
-        let out_fname = pe_zip_file.to_string_lossy().to_string();
-        prog_utils::download_to_file(dl_url, &out_fname)?;
+        prog_utils::download_to_file(dl_url, &pe_zip_file)?;
 
         // unzip
         let mut unzip_cmd = std::process::Command::new("unzip");


### PR DESCRIPTION
Here is Dongze from my Altos GitHub account ;)

I modified the followings:
1. I added a pre-defined custom_chemistries.json file in the resources directory. If this file is missing locally, it will be fetched just as permit list files. Correspondingly, i slightly changed the code for obtaining this file.
2. I added a struct called CBListInfo. This struct can
    1. check if the provided cb file needs to be parsed. If a CB file contains `\t`, it writes the first column (for each line, everything before the first `\t`) into a file `outdir/cb_list.txt`, which can be accepted by alevin-fry.
    2. After calling `alevin-fry quant`, it append the aux info (everything after the first `\t`) of each barcode to the corresponding line of the barcode in the `alevin/quants_mat_rows.txt` generated by alevin-fry.