### PR TITLE
fix(multiplex-quant): auto-download chemistry registry on first use

### DIFF
--- a/src/simpleaf_commands/multiplex_quant.rs
+++ b/src/simpleaf_commands/multiplex_quant.rs
@@ -11,7 +11,7 @@ use crate::core::{context, exec, index_meta};
 use crate::simpleaf_commands::MultiplexQuantOpts;
 use crate::utils::af_utils::IndexType;
 use crate::utils::chem_utils::{CustomChemistry, CustomChemistryMap};
-use crate::utils::constants::CHEMISTRIES_PATH;
+use crate::utils::constants::{CHEMISTRIES_PATH, CHEMISTRIES_URL};
 use crate::utils::probe_utils;
 use crate::utils::prog_parsing_utils;
 use crate::utils::prog_utils;
@@ -247,10 +247,7 @@ pub fn multiplex_map_and_quant(af_home: &Path, opts: MultiplexQuantOpts) -> anyh
     let chem: Option<CustomChemistry> = if let Some(ref chem_name) = opts.chemistry {
         let chem_path = af_home.join(CHEMISTRIES_PATH);
         if !chem_path.exists() {
-            bail!(
-                "Chemistry registry not found at {}. Run `simpleaf chemistry refresh` first.",
-                chem_path.display(),
-            );
+            prog_utils::download_to_file(CHEMISTRIES_URL, &chem_path)?;
         }
         let chem_file = std::fs::File::open(&chem_path)?;
         let chem_map: CustomChemistryMap = serde_json::from_reader(chem_file)


### PR DESCRIPTION
## Summary

`simpleaf multiplex-quant --chemistry <preset>` currently fails with:

```
Error: Chemistry registry not found at <af_home>/chemistries.json.
Run `simpleaf chemistry refresh` first.
```

on the first run after a fresh install (or any time `$ALEVIN_FRY_HOME/chemistries.json` doesn't exist yet).

`simpleaf quant` doesn't have this requirement — its chemistry-resolution path (`Chemistry::from_str` → `get_single_custom_chem_from_file` → `parse_resource_json_file`) auto-downloads `chemistries.json` from `CHEMISTRIES_URL` on first miss.

This PR replaces the explicit bail in `multiplex_map_and_quant` with the same `prog_utils::download_to_file` call that `parse_resource_json_file` itself uses, so the first-use UX of `multiplex-quant` matches `quant`.

## Diff

5 lines changed, 1 file. No new abstractions, no behavior change beyond the first-use auto-download.

## Test plan

- [x] Built with `cargo build --release`
- [x] With a fresh `$ALEVIN_FRY_HOME` (no `chemistries.json`), `simpleaf multiplex-quant --chemistry 10x-flexv2-gex-3p ...` now resolves the chemistry preset and proceeds (stops at the next downstream error, `--organism is required`, as expected). The registry file is downloaded into `$ALEVIN_FRY_HOME/chemistries.json` (7,463 bytes) during the call.
- [x] Subsequent runs reuse the existing file (no re-download — `chem_path.exists()` short-circuits).
- [x] The `bail!` for the file-missing case is removed but is replaced by `download_to_file`'s own error path, which surfaces clear network errors if the URL is unreachable.

## Related

Surfaced while debugging COMBINE-lab/simpleaf#195. Independent of that issue's collate-side fix.