### PR TITLE
feat(multiplex-quant): expose --sample-bc-ori as a CLI override

### DIFF
--- a/src/simpleaf_commands.rs
+++ b/src/simpleaf_commands.rs
@@ -573,13 +573,14 @@ pub struct MultiplexQuantOpts {
     #[arg(long, default_value = "both")]
     pub expected_ori: String,
 
-    /// Sample barcode orientation: `fw` (whitelist matches read as-is) or `rev`
-    /// (reverse-complement the whitelist before lookup). Overrides the chemistry
-    /// preset's `sample_bc_ori` when set. Useful for cycle-plan variants (e.g.
-    /// 10x Flex Configuration B) where the sample BC is read off the opposite
-    /// strand from the canonical preset. Shorthand mirrors `--expected-ori`.
+    /// Sample barcode orientation: `forward` (whitelist matches read as-is) or
+    /// `reverse` (reverse-complement the whitelist before lookup). Overrides
+    /// the chemistry preset's `sample_bc_ori` when set. Useful for cycle-plan
+    /// variants (e.g. 10x Flex Configuration B) where the sample BC is read
+    /// off the opposite strand from the canonical preset. Vocabulary matches
+    /// the preset JSON and alevin-fry's `--sample-bc-ori`.
     #[arg(long,
-        value_parser = clap::builder::PossibleValuesParser::new(["fw", "rev"]))]
+        value_parser = clap::builder::PossibleValuesParser::new(["forward", "reverse"]))]
     pub sample_bc_ori: Option<String>,
 
     /// Sample barcode correction mode

--- a/src/simpleaf_commands.rs
+++ b/src/simpleaf_commands.rs
@@ -573,6 +573,15 @@ pub struct MultiplexQuantOpts {
     #[arg(long, default_value = "both")]
     pub expected_ori: String,
 
+    /// Sample barcode orientation: `fw` (whitelist matches read as-is) or `rev`
+    /// (reverse-complement the whitelist before lookup). Overrides the chemistry
+    /// preset's `sample_bc_ori` when set. Useful for cycle-plan variants (e.g.
+    /// 10x Flex Configuration B) where the sample BC is read off the opposite
+    /// strand from the canonical preset. Shorthand mirrors `--expected-ori`.
+    #[arg(long,
+        value_parser = clap::builder::PossibleValuesParser::new(["fw", "rev"]))]
+    pub sample_bc_ori: Option<String>,
+
     /// Sample barcode correction mode
     #[arg(long, default_value = "exact",
         value_parser = clap::builder::PossibleValuesParser::new(["exact", "1-edit"]),

--- a/src/simpleaf_commands/multiplex_quant.rs
+++ b/src/simpleaf_commands/multiplex_quant.rs
@@ -403,14 +403,24 @@ pub fn multiplex_map_and_quant(af_home: &Path, opts: MultiplexQuantOpts) -> anyh
         .arg("--min-reads")
         .arg(format!("{}", opts.min_reads));
 
-    // If the chemistry declares a sample-barcode orientation (e.g. 10x Flex v2
-    // where the whitelist is the RC of what appears on the read), forward it.
-    if let Some(c) = chem.as_ref() {
-        if let Some(sbc_info) = c.sample_bc_list.as_ref() {
-            if let Some(ori) = sbc_info.sample_bc_ori.as_deref() {
-                gpl_cmd.arg("--sample-bc-ori").arg(ori);
-            }
-        }
+    // Forward the sample-barcode orientation to alevin-fry. Precedence:
+    //   1. user-supplied --sample-bc-ori CLI override (`fw`/`rev` shorthand,
+    //      mirroring --expected-ori; translated to alevin-fry's
+    //      `forward`/`reverse` vocabulary below).
+    //   2. the chemistry preset's declared sample_bc_ori string (passed as-is;
+    //      already `forward` / `reverse` in the JSON).
+    //   3. omit the flag (alevin-fry default).
+    let sbc_ori_override = match opts.sample_bc_ori.as_deref() {
+        Some("fw") => Some("forward"),
+        Some("rev") => Some("reverse"),
+        Some(_) => unreachable!("clap PossibleValuesParser restricts to fw/rev"),
+        None => chem
+            .as_ref()
+            .and_then(|c| c.sample_bc_list.as_ref())
+            .and_then(|s| s.sample_bc_ori.as_deref()),
+    };
+    if let Some(ori) = sbc_ori_override {
+        gpl_cmd.arg("--sample-bc-ori").arg(ori);
     }
 
     let gpl_cmd_str = prog_utils::get_cmd_line_string(&gpl_cmd);

--- a/src/simpleaf_commands/multiplex_quant.rs
+++ b/src/simpleaf_commands/multiplex_quant.rs
@@ -404,21 +404,16 @@ pub fn multiplex_map_and_quant(af_home: &Path, opts: MultiplexQuantOpts) -> anyh
         .arg(format!("{}", opts.min_reads));
 
     // Forward the sample-barcode orientation to alevin-fry. Precedence:
-    //   1. user-supplied --sample-bc-ori CLI override (`fw`/`rev` shorthand,
-    //      mirroring --expected-ori; translated to alevin-fry's
-    //      `forward`/`reverse` vocabulary below).
-    //   2. the chemistry preset's declared sample_bc_ori string (passed as-is;
-    //      already `forward` / `reverse` in the JSON).
+    //   1. user-supplied --sample-bc-ori CLI override (`forward` / `reverse`,
+    //      matching alevin-fry's vocabulary and the preset JSON).
+    //   2. the chemistry preset's declared sample_bc_ori (e.g. 10x Flex v2
+    //      where the whitelist is the RC of what appears on the read).
     //   3. omit the flag (alevin-fry default).
-    let sbc_ori_override = match opts.sample_bc_ori.as_deref() {
-        Some("fw") => Some("forward"),
-        Some("rev") => Some("reverse"),
-        Some(_) => unreachable!("clap PossibleValuesParser restricts to fw/rev"),
-        None => chem
-            .as_ref()
+    let sbc_ori_override = opts.sample_bc_ori.as_deref().or_else(|| {
+        chem.as_ref()
             .and_then(|c| c.sample_bc_list.as_ref())
-            .and_then(|s| s.sample_bc_ori.as_deref()),
-    };
+            .and_then(|s| s.sample_bc_ori.as_deref())
+    });
     if let Some(ori) = sbc_ori_override {
         gpl_cmd.arg("--sample-bc-ori").arg(ori);
     }


### PR DESCRIPTION
## Summary

Adds `--sample-bc-ori {forward,reverse}` to `simpleaf multiplex-quant`, completing the precedence pattern that `--expected-ori` and `--geometry` already follow:

1. user-supplied CLI value (this PR)
2. chemistry preset's declared `sample_bc_ori`
3. omit the flag (alevin-fry default = `forward`)

Resolves the use case in #198: cycle-plan variants like 10x Flex Configuration B (R1=28 / R2=90) where the sample BC is read from the opposite strand. Users can now run such variants with `--chemistry 10x-flexv2-gex-3p --geometry '...' --sample-bc-ori forward` without adding a new preset entry.

## Implementation notes

- **CLI vocabulary:** `forward` / `reverse` — matches the chemistry preset JSON (`"sample_bc_ori": "forward" | "reverse"`) and alevin-fry's own `--sample-bc-ori` flag (verified in [alevin-fry main.rs](https://github.com/COMBINE-lab/alevin-fry/blob/main/src/main.rs)).
- **No translation layer:** The CLI value is forwarded verbatim to alevin-fry's `generate-permit-list --sample-bc-ori`.
- **Preset JSON untouched:** When the override comes from the chemistry preset's `Option<String>` field, it passes through verbatim. No breaking change to existing `chemistries.json`.
- **No `both`:** alevin-fry's `--sample-bc-ori` only accepts `forward`/`reverse`. No current preset declares `both` either. Adding `both` would mean inventing semantics that don't exist downstream.

## Validation

End-to-end verified by running the same internal Config B Flex library two ways and confirming byte-identical results:

- **Path A (preset-driven):** `--chemistry 10x-flexv2-gex-3p-config-b` (from the companion preset PR #201, which declares `sample_bc_ori: "forward"`).
- **Path B (CLI-override):** `--chemistry 10x-flexv2-gex-3p` (which declares `sample_bc_ori: "reverse"` in its JSON) + `--sample-bc-ori forward` + matching `--geometry` override at the CLI.

Both runs produced identical per-sample-well cell counts and read counts, identical wall-clock time, and `sample_bc_ori: Forward` in the resulting `sample_info.json`. That demonstrates:

1. The CLI value reaches `alevin-fry generate-permit-list` correctly (the demultiplexing wells light up, instead of producing the noise-floor result the preset's declared `reverse` would yield on Config B reads).
2. The precedence rule is correct: when CLI and preset disagree, the CLI value wins.

## CI status note

The `check_formatting` job fails on this PR with a `SIGILL` from `alevin-fry --version` during `test_simpleaf.sh`. **This is a pre-existing failure on upstream `main`** since commit `52ccc73` (the 0.25.0 release): the bioconda alevin-fry 0.15.0 binary appears to use CPU instructions not supported by the GHA runner. My PR does not touch any code path involved in the failure (`set-paths` runs before any `--sample-bc-ori` code is exercised). Suggested fixes (`cargo install` from source in CI, or a bioconda rebuild) are out of scope for this PR; happy to send them separately if desired.

## Test plan

- [x] `cargo check` passes locally on the patched source.
- [x] `cargo build --release` produces a working binary that runs through `multiplex-quant`.
- [x] End-to-end run with `--sample-bc-ori forward` on a real Config B Flex library yields realistic per-sample-well cell counts (matches cellranger multi ground truth at the well level).
- [x] Result is byte-identical to the companion preset path in PR #201 (rules out silent path divergence).
- [x] `sample_bc_ori` is recorded in `sample_info.json` as the value passed at the CLI, confirming it flowed through to `alevin-fry generate-permit-list`.
- [ ] `check_formatting` CI job (pre-existing SIGILL on upstream main; see CI status note above).

## Refs

- #198 (Config B preset request — this PR is the general fix the second comment proposed)
- #201 (companion: adds `10x-flexv2-gex-3p-config-b` chemistry preset that exercises the same `sample_bc_ori` field via the preset path)