### PR TITLE
feat(chemistries): add 10x-flexv2-gex-3p-config-b preset

### DIFF
--- a/resources/chemistries.json
+++ b/resources/chemistries.json
@@ -196,5 +196,33 @@
         "remote_url": "https://umd.box.com/shared/static/z21ofrtnj3t33fb0mti66dc319cgvnuq"
       }
     }
+  },
+  "10x-flexv2-gex-3p-config-b": {
+    "geometry": "1{b[16]u[12]x:}2{r[50]f[CCCATATAAGAAAACCTGAATACGCGGTT]s[10]x:}",
+    "expected_ori": "both",
+    "version": "0.1.0",
+    "plist_name": "dcb018db2e9d7023ac077eb2477b877163fa5dcef7b8e39e0826bc2560c29cf9",
+    "remote_url": "https://umd.box.com/shared/static/fei8u0tcve2wu73q4qxrskwl3gs7svj1",
+    "meta": {
+      "cr_filename": "737K-flex-v2.txt",
+      "protocol_type": "flex_gex"
+    },
+    "sample_bc_list": {
+      "plist_name": "5e7ef950ad43c35525e8d923423a7bb1abdce78ca2a8fe4ef9a2d69c5f22830b",
+      "remote_url": "https://umd.box.com/shared/static/4ogdlgooo1onjkrny9pfbyz4gdt5vktl",
+      "sample_bc_ori": "forward"
+    },
+    "probe_sets": {
+      "human": {
+        "name": "Chromium_Human_Transcriptome_Probe_Set_v2.0.0_GRCh38-2024-A",
+        "plist_name": "bfa53e2acde140d6bd90c3b21d65c48c5b04e3064adee7402d3016116db04958",
+        "remote_url": "https://umd.box.com/shared/static/2fd0tda0638wy0fclgh3ywdgul1g53pi"
+      },
+      "mouse": {
+        "name": "Chromium_Mouse_Transcriptome_Probe_Set_v2.0.0_GRCm39-2024-A",
+        "plist_name": "8e0ea460bc5a93df85cf5c4f321c62a3e50ad01b5589a8c0c9559bf554f6f276",
+        "remote_url": "https://umd.box.com/shared/static/z21ofrtnj3t33fb0mti66dc319cgvnuq"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds a chemistry preset for 10x Genomics GEM-X Flex v2 **sequencing Configuration B** (R1=28 / R2=90), as documented in 10x's [Sequencing Requirements for Single Cell Gene Expression Flex](https://www.10xgenomics.com/support/flex-gene-expression/documentation/steps/sequencing/sequencing-requirements-for-single-cell-gene-expression-flex).

Users running Config B today have to override `--geometry` and `--sample-bc-ori` by hand (or use the new CLI flag from #199). This preset gives them a one-line `--chemistry 10x-flexv2-gex-3p-config-b` option that resolves all preset-controlled parameters automatically — geometry, sample BC orientation, cell BC whitelist, sample BC TSV, and per-organism probe sets.

## Two fields differ from `10x-flexv2-gex-3p`

All other assets (`plist_name`, `remote_url`, `sample_bc_list.{plist_name,remote_url}`, `probe_sets.human/mouse`, `meta`) are byte-identical to the Config A preset.

```diff
- "geometry": "1{b[16]u[12]x[0-3]f[TTGCTAGGACCG]s[10]x:}2{r:}",
+ "geometry": "1{b[16]u[12]x:}2{r[50]f[CCCATATAAGAAAACCTGAATACGCGGTT]s[10]x:}",
...
-     "sample_bc_ori": "reverse"
+     "sample_bc_ori": "forward"
```

**Why geometry differs:** In Config B, R1 ends at 28 bp (cell BC + UMI only — no room for the probe-side anchor `TTGCTAGGACCG` that Config A uses), and R2 reads 90 bp from the probe end. So the 29 bp constant `CCCATATAAGAAAACCTGAATACGCGGTT` (the RC of 10x's documented sense-strand `AACCGCGTATTCAGGTTTTCTTATATGGG`), the 10 bp sample BC, and the 50 bp probe-mappable region all live on R2 in that order.

**Why sample_bc_ori differs:** R2 reads the opposite strand vs R1's "view" of the library construct, so the canonical sample BC appears in the read in its forward-canonical form (whereas Config A reads the BC's RC on R1's strand).

## Validation

End-to-end verified by running `simpleaf multiplex-quant --chemistry 10x-flexv2-gex-3p-config-b --organism mouse --probe-set <mouse probe CSV>` against an internal Config B Flex library and comparing against the corresponding cellranger ground truth:

- High overall mapping rate against the auto-built probe index, consistent with what other Flex presets produce on Config A data.
- Sample BC demultiplexing recovers exactly the wells declared in the cellranger multi config, with realistic cell counts per well; unused wells stay at the noise floor (≤1 cell / few reads).
- The same input run against the `10x-flexv2-gex-3p` (Config A) preset produces noise-floor sample-BC matches only, confirming the `sample_bc_ori`/geometry split between the two presets is real, not a CLI quirk.

## Relation to #199

#199 exposes `--sample-bc-ori` as a CLI override, which is the general fix for cycle-plan variants. This PR is complementary, not redundant: the preset gives Config B users `--chemistry 10x-flexv2-gex-3p-config-b` as a one-line alternative to remembering the right geometry + override combo. Both code paths were validated against the same dataset and produce byte-identical results, confirming the preset's declared fields and the CLI override flow into the same downstream pipeline.

## Test plan

- [x] JSON parses (validated via `python3 -m json.tool`).
- [x] Preset entry is sibling-style appended after `10x-flexv2-gex-3p` with the same field order — minimal diff (+28 lines), no whitespace churn on unrelated entries.
- [x] End-to-end run with `--chemistry 10x-flexv2-gex-3p-config-b` against a real Config B Flex library: ~98% mapping rate, all expected sample wells recover with realistic cell counts, unused wells at noise floor.
- [x] Byte-identical results vs the CLI-override path in PR #199 (rules out preset-vs-CLI divergence).
- [x] `simpleaf inspect` lists the new preset alongside the existing ones (chemistries.json registry load path works).

Closes #198.