### PR TITLE
Cache Rust builds and remove ineffective thin LTO

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,10 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ join(matrix.targets, '-') }}
+          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/test_simpleaf.yml
+++ b/.github/workflows/test_simpleaf.yml
@@ -29,6 +29,15 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt
+
+      # simpleaf has a large, stable dependency graph (notably Polars and
+      # HDF5). Cache dependency artifacts separately for each runner/toolchain;
+      # rust-cache derives the remaining key from Cargo.lock and the Rust
+      # environment, and deliberately excludes simpleaf itself.
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       
       # Cheap and compiles nothing, so it runs first.
       - name: Check formatting
@@ -38,9 +47,9 @@ jobs:
         run: cargo build --verbose --release
 
       # Deliberately `--release`: it reuses the artifacts the Build step just
-      # produced, which makes this ~30s. A debug `cargo test` would rebuild the
-      # whole dependency graph in a second profile — including HDF5, which is
-      # compiled from source — and cost minutes.
+      # produced. A debug `cargo test` would rebuild the whole dependency graph
+      # in a second profile — including HDF5, which is compiled from source —
+      # and cost minutes.
       #
       # This job previously ran neither this nor `cargo fmt`, which is how a
       # test that did not compile, and a stale CLI snapshot, both reached main.

--- a/.github/workflows/test_simpleaf.yml
+++ b/.github/workflows/test_simpleaf.yml
@@ -21,13 +21,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.4.2
+        uses: actions/checkout@v6
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
           components: rustfmt
 
       # simpleaf has a large, stable dependency graph (notably Polars and
@@ -63,7 +61,7 @@ jobs:
         run: cargo doc --no-deps
 
       - name: Install conda env
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           channels: conda-forge,default,bioconda
           channel-priority: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4629,7 +4629,6 @@ dependencies = [
  "af-anndata",
  "anyhow",
  "blake3",
- "cc",
  "chrono",
  "clap",
  "cmd_lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,6 @@ categories = ["command-line-utilities", "science"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-cc = "1.2.20"
-
 # seq_geom_parser (chumsky-based, from the piscem-rs workspace) — used for
 # geometry validation and multiplex-quant. Published on crates.io; the
 # `.cargo/config.toml` patch this comment used to describe is long gone (there
@@ -107,11 +105,6 @@ tempfile = "3.19.1"
 ureq = { version = "3.0.11", features = ["json"] }
 file-requirements = "0.1.0"
 
-[profile.release]
-lto = "thin"
-opt-level = 3
-
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"
-lto = "thin"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -13,6 +13,10 @@ installers = ["shell"]
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
+# Preserve compiled dependency artifacts between release builds. This is most
+# useful when rerunning a failed release or when dependencies stay fixed across
+# patch releases; cargo-dist keys each target independently.
+cache-builds = true
 # Whether to install an updater program
 install-updater = true
 # Path that installers should place binaries in


### PR DESCRIPTION
## Summary

- cache Rust dependency artifacts in the regular Linux/macOS CI matrix
- enable cargo-dist's supported per-target release-build cache and regenerate the 0.31 workflow
- remove thin LTO from release and distribution builds
- remove simpleaf's unused direct cc dependency (cc remains transitively where native builds need it)
- move checkout, Rust setup, and setup-miniconda to their supported Node 24-era actions

The cache deliberately leaves the simpleaf crate itself uncached. Rust-cache keys dependency artifacts by runner, toolchain, Cargo manifests/lockfile, and compiler environment. Release caching is declared through cache-builds in dist-workspace.toml, rather than as a hand edit to generated CI.

## LTO measurement

Controlled clean-target release builds used the same checkout, host, Rust toolchain, and 16-way build:

| configuration | wall | peak RSS | unstripped binary | stripped xz |
|---|---:|---:|---:|---:|
| thin LTO | 101.89 s | 4,142,812 KiB | 128,445,728 B | 15,726,188 B |
| LTO off | 95.58 s | 3,643,372 KiB | 129,739,680 B | 15,541,484 B |

Disabling thin LTO reduced wall time by 6.2% and peak compiler RSS by 12.1%. The distributable-size proxy was 1.2% smaller without LTO.

Five alternating 1,000-process batches showed no measurable runtime change: median quant-help time was 1.84 s for both binaries, and median chemistry-registry load/lookup time was 1.80 s for both. Because simpleaf delegates mapping, collation, quantification, and index construction to child programs, there is no demonstrated end-user runtime benefit to pay for thin LTO here.

## CI cache measurement

An identical rerun of the final commit, after its cache-seeding run completed, produced:

| runner | cold | warm | reduction |
|---|---:|---:|---:|
| ubuntu-latest | 16m25s | 2m49s | 82.8% |
| macos-15 | 13m01s | 2m21s | 81.9% |

Both warm jobs ran the full workflow, including release build/tests, strict rustdoc on Linux, conda environment setup, the released alevin-fry artifact, and the toy end-to-end pipeline. The cache archives were 858 MB on Linux and 516 MB on macOS.

## Validation

- all 77 release-profile tests pass
- strict rustdoc passes
- Cargo metadata resolves with the lockfile
- both workflows parse as YAML
- cargo-dist 0.31 regenerates the release workflow cleanly and generate --check passes
